### PR TITLE
fix reviewdog-ci

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           go-version: '1.22'
 
+      - name: Install dependencies
+        run: go mod download
+
       - name: staticcheck
         uses: reviewdog/action-staticcheck@v1
         with:
@@ -30,4 +33,5 @@ jobs:
           reporter: github-pr-review
           filter_mode: nofilter
           fail_level: warning
-          workdir: .
+          workdir: "."
+          golangci_lint_flags: "--timeout=5m"

--- a/internal/app/kabuka/kabuka.go
+++ b/internal/app/kabuka/kabuka.go
@@ -83,7 +83,7 @@ func isSymbolNotFound(res *http.Response) bool {
 func (k *Kabuka) formatOutput(stock *model.Stock) (string, error) {
 	var result string
 
-	switch k.Option.Format {
+	switch k.Format {
 	case OutputFormatTypeText:
 		result = fmt.Sprintf("%s\t%s", stock.CurrentPrice, stock.Symbol)
 	case OutputFormatTypeJson:

--- a/internal/app/kabuka/model.go
+++ b/internal/app/kabuka/model.go
@@ -1,8 +1,9 @@
 package kabuka
 
 import (
-	"golang.org/x/xerrors"
 	"strings"
+
+	"golang.org/x/xerrors"
 )
 
 // Option execution parameters
@@ -40,6 +41,6 @@ func ParseOutputFormat(s string) (OutputFormatType, error) {
 
 // SanitizeInput returns sanitized string
 func SanitizeInput(s string) string {
-	result := strings.Replace(s, "\n", "", -1)
-	return strings.Replace(result, "\r", "", -1)
+	result := strings.ReplaceAll(s, "\n", "")
+	return strings.ReplaceAll(result, "\r", "")
 }


### PR DESCRIPTION
## Description
This PR fixes the failing golangci-lint check in the GitHub Actions workflow. The linter was failing with the error "no go files to analyze" due to missing Go module setup.

## Changes
- Added a new step to install Go dependencies using `go mod download` before running the linters
- Added `golangci_lint_flags` with a 5-minute timeout to prevent the linter from timing out on larger codebases
- Ensured the `workdir` is properly set to the root of the repository

## Why
The previous workflow configuration was missing the necessary step to download Go dependencies before running the linters. This caused the golangci-lint to fail because it couldn't find the Go files to analyze. The added timeout flag also helps prevent the linter from timing out on larger codebases.

## Testing
- The workflow should now successfully run the golangci-lint check on pull requests
- The linter will have proper access to all Go files in the repository
- Dependencies will be correctly downloaded before linting begins