### PR TITLE
Initialize Claude Code setup: CLAUDE.md, test refactor, and add-fetcher skill

### DIFF
--- a/.claude/skills/add-fetcher/SKILL.md
+++ b/.claude/skills/add-fetcher/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: add-fetcher
+description: Add a new stock market fetcher to the kabuka project
+disable-model-invocation: true
+---
+Add a new market fetcher for: $ARGUMENTS
+
+Steps:
+
+1. Identify the exact market name string Yahoo Finance uses in the DOM — inspect the element targeted by `selectorMarketNameSingle` in `fetcher/fetcher.go` on a real Yahoo Finance page for that market.
+
+2. Create `internal/app/kabuka/fetcher/<market>/` with a `<market>_fetcher.go` file. Use `fetcher/jp/jp_fetcher.go` as the reference implementation.
+
+3. Implement the `Fetcher` interface:
+   - `IsMarket(doc *goquery.Document) bool` — use `fetcher.GetMarketName(doc)` and match against the market name(s) identified in step 1
+   - `Fetch(doc *goquery.Document, symbol string) (*model.Stock, error)` — extract price using `doc.Find(selectorCurrentPrice).Text()` then wrap with `fetcher.FormatPrice()`
+
+4. Register via `init()`:
+   ```go
+   func init() {
+       fetcher.RegisterFetcher(&<market>Fetcher{})
+   }
+   ```
+
+5. Add a blank import in `internal/app/kabuka/kabuka.go`:
+   ```go
+   _ "github.com/shionit/kabuka/internal/app/kabuka/fetcher/<market>"
+   ```
+
+6. Add integration test cases to `kabuka_integration_test.go` covering at least one symbol from the new market.
+
+7. Verify:
+   ```bash
+   go build ./...
+   go test -tags integration -run TestKabuka_fetch ./internal/app/kabuka/...
+   ```

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # vendor/
 /coverage.html
 /gotest.profile
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Build
+go build -o bin/ -v ./...
+
+# Run unit tests (no network, fast)
+make test
+
+# Run integration tests (requires live network access to Yahoo Finance)
+make test-integration
+
+# Run a single test
+go test -v -run TestFunctionName ./internal/app/kabuka/...
+
+# Run tests with coverage (full, includes integration)
+make test-coverage
+```
+
+Linting runs via CI (golangci-lint, staticcheck via reviewdog). To run locally:
+```bash
+golangci-lint run
+staticcheck ./...
+```
+
+## Architecture
+
+**kabuka** is a CLI tool that fetches stock prices from Yahoo! Finance Japan (`finance.yahoo.co.jp`), supporting both Japanese (東証, 名証, etc.) and US (NASDAQ, NYSE) markets.
+
+### Execution Flow
+
+```
+cmd/root.go (Cobra CLI) → Kabuka.Execute() → Kabuka.fetch() → SelectFetcher() → Fetcher.Fetch() → formatOutput()
+```
+
+1. **`cmd/root.go`** — Cobra command definition; parses symbol arg and `-f/--format` flag (text/json/csv), then calls `Kabuka.Execute()`
+2. **`internal/app/kabuka/kabuka.go`** — Core orchestration: HTTP GET to Yahoo Finance search, handles search result pages by following targeted product links, delegates HTML parsing to the appropriate fetcher
+3. **`internal/app/kabuka/fetcher/fetcher.go`** — Fetcher interface (`IsMarket(doc) bool`, `Fetch(doc, symbol) Stock`) plus registry (`RegisterFetcher` / `SelectFetcher`)
+4. **`internal/app/kabuka/fetcher/jp/`** and **`fetcher/us/`** — Concrete fetcher implementations; registered via `init()`, detect their market from DOM, extract current price via CSS selectors
+
+### Plugin Pattern for Fetchers
+
+New market support is added by:
+1. Implementing the `Fetcher` interface in a new package under `fetcher/`
+2. Calling `fetcher.RegisterFetcher()` in the package's `init()`
+3. Importing the package (blank import) in `kabuka.go`
+
+### Key Design Notes
+
+- Price extraction uses hardcoded CSS selectors against Yahoo Finance's DOM — changes to Yahoo Finance's HTML will break parsing
+- `SanitizeInput()` strips newlines/carriage returns from user-supplied symbols
+- `FormatPrice()` strips commas before returning numeric price strings
+
+## Gotchas
+
+- **CSS selector fragility**: All fetchers (`fetcher/jp/`, `fetcher/us/`) hardcode deep CSS selectors against Yahoo Finance's DOM. When fetching silently breaks, inspect `selectorCurrentPrice` and `selectorMarketNameSingle` against the current live page first — Yahoo Finance HTML changes will cascade to all fetchers at once.
+- **Integration tests require live network**: `TestKabuka_fetch` (in `kabuka_integration_test.go`, build tag `integration`) makes real HTTP requests to Yahoo Finance. These tests fail without internet access and may return `"---"` during non-market hours — this is expected behaviour, not a bug. Use `make test` for offline development.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-test-coverage:
-	go test -v -coverprofile=./gotest.profile ./... 2>&1
-	go tool cover -html=./gotest.profile -o ./coverage.html
+test:
+	go test -v ./...
 
+test-integration:
+	go test -v -tags integration ./...
+
+test-coverage:
+	go test -v -tags integration -coverprofile=./gotest.profile ./... 2>&1
+	go tool cover -html=./gotest.profile -o ./coverage.html

--- a/internal/app/kabuka/kabuka.go
+++ b/internal/app/kabuka/kabuka.go
@@ -35,11 +35,16 @@ func (k *Kabuka) Execute() error {
 
 // fetch stock information from finance website.
 func (k *Kabuka) fetch() (*model.Stock, error) {
-	client := http.Client{
-		Timeout: 10 * time.Second,
+	client := k.httpClient
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	baseURL := k.baseURL
+	if baseURL == "" {
+		baseURL = financeSiteUrl
 	}
 	// Yahoo! Finance Web scraping
-	res, err := client.Get(financeSiteUrl + k.Symbol)
+	res, err := client.Get(baseURL + k.Symbol)
 	if err != nil {
 		return nil, xerrors.Errorf("Http client Get failed, err: %w", err)
 	}
@@ -54,7 +59,7 @@ func (k *Kabuka) fetch() (*model.Stock, error) {
 	}
 
 	// Check if we're on a search results page (multiple results)
-	if isSearchResultsPage(res) {
+	if isSearchResultsPage(res, baseURL) {
 		// Try to find and follow the correct product link
 		productURL, err := findProductLinkFromSearchResults(res, k.Symbol)
 		if err != nil {
@@ -97,10 +102,10 @@ func (k *Kabuka) fetch() (*model.Stock, error) {
 }
 
 // isSearchResultsPage checks if the response is a search results page (multiple results)
-func isSearchResultsPage(res *http.Response) bool {
+func isSearchResultsPage(res *http.Response, baseURL string) bool {
 	url := res.Request.URL.String()
 	// If location is back to search page, we have multiple results
-	return strings.HasPrefix(url, financeSiteUrl)
+	return strings.HasPrefix(url, baseURL)
 }
 
 // findProductLinkFromSearchResults extracts the correct product link from search results

--- a/internal/app/kabuka/kabuka_integration_test.go
+++ b/internal/app/kabuka/kabuka_integration_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+// anyPrice is a sentinel used in integration tests to indicate "any non-empty price is acceptable".
+const anyPrice = "any price"
+
 func TestKabuka_fetch(t *testing.T) {
 	type fields struct {
 		Option Option

--- a/internal/app/kabuka/kabuka_integration_test.go
+++ b/internal/app/kabuka/kabuka_integration_test.go
@@ -1,0 +1,145 @@
+//go:build integration
+
+package kabuka
+
+import (
+	"strconv"
+	"testing"
+
+	_ "github.com/shionit/kabuka/internal/app/kabuka/fetcher/jp"
+	_ "github.com/shionit/kabuka/internal/app/kabuka/fetcher/us"
+
+	"github.com/shionit/kabuka/internal/app/kabuka/model"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestKabuka_fetch(t *testing.T) {
+	type fields struct {
+		Option Option
+	}
+	type testStock struct {
+		*model.Stock
+		isWant bool
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    *model.Stock
+		wantErr bool
+	}{
+		{
+			name: "if kabuka 3994.T @東証PRM then Money Forward, Inc.",
+			fields: fields{
+				Option: Option{
+					Symbol: "3994.T",
+				},
+			},
+			want: &model.Stock{
+				Symbol:       "3994.T",
+				CurrentPrice: anyPrice,
+			},
+		},
+		{
+			name: "if kabuka 4412 @東証GRT then Science Arts, Inc.",
+			fields: fields{
+				Option: Option{
+					Symbol: "4412",
+				},
+			},
+			want: &model.Stock{
+				Symbol:       "4412.T",
+				CurrentPrice: anyPrice,
+			},
+		},
+		{
+			name: "if kabuka 8604.T @東証PRM then Nomura Holdings, Inc. (IP for multi market)",
+			fields: fields{
+				Option: Option{
+					Symbol: "8604.T",
+				},
+			},
+			want: &model.Stock{
+				Symbol:       "8604.T",
+				CurrentPrice: anyPrice,
+			},
+		},
+		{
+			name: "if kabuka NMR @NYSE then Nomura Holdings, Inc. (IP for multi market)",
+			fields: fields{
+				Option: Option{
+					Symbol: "NMR",
+				},
+			},
+			want: &model.Stock{
+				Symbol:       "NMR",
+				CurrentPrice: anyPrice,
+			},
+		},
+		{
+			name: "if kabuka AAPL @NASDAQ then Apple Inc.",
+			fields: fields{
+				Option: Option{
+					Symbol: "AAPL",
+				},
+			},
+			want: &model.Stock{
+				Symbol:       "AAPL",
+				CurrentPrice: anyPrice,
+			},
+		},
+		{
+			name: "if kabuka WRONG999 then error.",
+			fields: fields{
+				Option: Option{
+					Symbol: "WRONG999",
+				},
+			},
+			wantErr: true,
+		},
+	}
+	opts := []cmp.Option{
+		cmp.Comparer(func(a *testStock, b *testStock) bool {
+			if a.Symbol != b.Symbol {
+				return false
+			}
+			var want, got *testStock
+			if a.isWant {
+				want, got = a, b
+			} else {
+				want, got = b, a
+			}
+			if want.CurrentPrice == anyPrice {
+				if got.CurrentPrice == "---" {
+					return true // when market is closed
+				}
+				// success if any float number
+				_, err := strconv.ParseFloat(got.CurrentPrice, 32)
+				return err == nil
+			}
+			return want.CurrentPrice == got.CurrentPrice
+		}),
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := &Kabuka{
+				Option: tt.fields.Option,
+			}
+			got, err := k.fetch()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Fetch() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				return
+			}
+			want := &testStock{
+				tt.want,
+				true,
+			}
+			if diff := cmp.Diff(want, &testStock{got, false}, opts...); diff != "" {
+				t.Errorf("Fetch() diff(-want +got): %v", diff)
+			}
+		})
+	}
+}

--- a/internal/app/kabuka/kabuka_test.go
+++ b/internal/app/kabuka/kabuka_test.go
@@ -12,10 +12,6 @@ import (
 	"github.com/shionit/kabuka/internal/app/kabuka/model"
 )
 
-const (
-	anyPrice = "any price"
-)
-
 // jpStockHTML returns minimal HTML that satisfies the JP fetcher's CSS selectors.
 func jpStockHTML(marketName, price string) string {
 	return fmt.Sprintf(`<html><body>

--- a/internal/app/kabuka/kabuka_test.go
+++ b/internal/app/kabuka/kabuka_test.go
@@ -69,7 +69,9 @@ func TestKabuka_fetch_unit(t *testing.T) {
 			html := tt.html
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == "/quote/"+tt.symbol {
-					fmt.Fprint(w, html)
+					if _, err := fmt.Fprint(w, html); err != nil {
+						t.Errorf("failed to write response: %v", err)
+					}
 				} else {
 					http.Redirect(w, r, "/quote/"+tt.symbol, http.StatusFound)
 				}

--- a/internal/app/kabuka/kabuka_test.go
+++ b/internal/app/kabuka/kabuka_test.go
@@ -1,146 +1,103 @@
 package kabuka
 
 import (
-	"strconv"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	_ "github.com/shionit/kabuka/internal/app/kabuka/fetcher/jp"
 	_ "github.com/shionit/kabuka/internal/app/kabuka/fetcher/us"
 
 	"github.com/shionit/kabuka/internal/app/kabuka/model"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 const (
 	anyPrice = "any price"
 )
 
-func TestKabuka_fetch(t *testing.T) {
-	type fields struct {
-		Option Option
-	}
-	type testStock struct {
-		*model.Stock
-		isWant bool
-	}
+// jpStockHTML returns minimal HTML that satisfies the JP fetcher's CSS selectors.
+func jpStockHTML(marketName, price string) string {
+	return fmt.Sprintf(`<html><body>
+<div id="root"><main><div><section>
+  <div class="PriceBoardMenu__3fnA PriceBoard__menu__ISpY"><span>%s</span></div>
+  <div class="PriceBoard__main__1liM">
+    <div class="PriceBoard__priceInformation__78Tl">
+      <div class="PriceBoard__priceBlock__1PmX"><span><span><span>%s</span></span></span></div>
+    </div>
+  </div>
+</section></div></main></div>
+</body></html>`, marketName, price)
+}
+
+// usStockHTML returns minimal HTML that satisfies the US fetcher's CSS selectors.
+func usStockHTML(marketName, price string) string {
+	return jpStockHTML(marketName, price) // identical structure, different market name
+}
+
+func TestKabuka_fetch_unit(t *testing.T) {
 	tests := []struct {
-		name    string
-		fields  fields
-		want    *model.Stock
-		wantErr bool
+		name       string
+		symbol     string
+		html       string
+		wantSymbol string
+		wantPrice  string
+		wantErr    bool
 	}{
 		{
-			name: "if kabuka 3994.T @東証PRM then Money Forward, Inc.",
-			fields: fields{
-				Option: Option{
-					Symbol: "3994.T",
-				},
-			},
-			want: &model.Stock{
-				Symbol:       "3994.T",
-				CurrentPrice: anyPrice,
-			},
+			name:       "JP stock (東証PRM)",
+			symbol:     "3994.T",
+			html:       jpStockHTML("東証PRM", "1,234.56"),
+			wantSymbol: "3994.T",
+			wantPrice:  "1234.56",
 		},
 		{
-			name: "if kabuka 4412 @東証GRT then Science Arts, Inc.",
-			fields: fields{
-				Option: Option{
-					Symbol: "4412",
-				},
-			},
-			want: &model.Stock{
-				Symbol:       "4412.T",
-				CurrentPrice: anyPrice,
-			},
+			name:       "US stock (NASDAQ)",
+			symbol:     "AAPL",
+			html:       usStockHTML("NASDAQ", "189.30"),
+			wantSymbol: "AAPL",
+			wantPrice:  "189.30",
 		},
 		{
-			name: "if kabuka 8604.T @東証PRM then Nomura Holdings, Inc. (IP for multi market)",
-			fields: fields{
-				Option: Option{
-					Symbol: "8604.T",
-				},
-			},
-			want: &model.Stock{
-				Symbol:       "8604.T",
-				CurrentPrice: anyPrice,
-			},
-		},
-		{
-			name: "if kabuka NMR @NYSE then Nomura Holdings, Inc. (IP for multi market)",
-			fields: fields{
-				Option: Option{
-					Symbol: "NMR",
-				},
-			},
-			want: &model.Stock{
-				Symbol:       "NMR",
-				CurrentPrice: anyPrice,
-			},
-		},
-		{
-			name: "if kabuka AAPL @NASDAQ then Apple Inc.",
-			fields: fields{
-				Option: Option{
-					Symbol: "AAPL",
-				},
-			},
-			want: &model.Stock{
-				Symbol:       "AAPL",
-				CurrentPrice: anyPrice,
-			},
-		},
-		{
-			name: "if kabuka WRONG999 then error.",
-			fields: fields{
-				Option: Option{
-					Symbol: "WRONG999",
-				},
-			},
+			name:    "unknown market returns error",
+			symbol:  "UNKNOWN",
+			html:    `<html><body><div id="root"></div></body></html>`,
 			wantErr: true,
 		},
 	}
-	opts := []cmp.Option{
-		cmp.Comparer(func(a *testStock, b *testStock) bool {
-			if a.Symbol != b.Symbol {
-				return false
-			}
-			var want, got *testStock
-			if a.isWant {
-				want, got = a, b
-			} else {
-				want, got = b, a
-			}
-			if want.CurrentPrice == anyPrice {
-				if got.CurrentPrice == "---" {
-					return true // when market is closed
-				}
-				// success if any float number
-				_, err := strconv.ParseFloat(got.CurrentPrice, 32)
-				return err == nil
-			}
-			return want.CurrentPrice == got.CurrentPrice
-		}),
-	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// The server mirrors Yahoo Finance: /search/?query=SYM redirects to /quote/SYM,
+			// which is what isSearchResultsPage relies on to detect non-search pages.
+			html := tt.html
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/quote/"+tt.symbol {
+					fmt.Fprint(w, html)
+				} else {
+					http.Redirect(w, r, "/quote/"+tt.symbol, http.StatusFound)
+				}
+			}))
+			defer srv.Close()
+
 			k := &Kabuka{
-				Option: tt.fields.Option,
+				Option:  Option{Symbol: tt.symbol},
+				baseURL: srv.URL + "/search/?query=",
 			}
 			got, err := k.fetch()
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Fetch() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("fetch() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if err != nil {
+			if tt.wantErr {
 				return
 			}
-			want := &testStock{
-				tt.want,
-				true,
+			want := &model.Stock{Symbol: tt.wantSymbol, CurrentPrice: tt.wantPrice}
+			if got.Symbol != want.Symbol {
+				t.Errorf("Symbol = %q, want %q", got.Symbol, want.Symbol)
 			}
-			if diff := cmp.Diff(want, &testStock{got, false}, opts...); diff != "" {
-				t.Errorf("Fetch() diff(-want +got): %v", diff)
+			if got.CurrentPrice != want.CurrentPrice {
+				t.Errorf("CurrentPrice = %q, want %q", got.CurrentPrice, want.CurrentPrice)
 			}
 		})
 	}

--- a/internal/app/kabuka/model.go
+++ b/internal/app/kabuka/model.go
@@ -1,6 +1,7 @@
 package kabuka
 
 import (
+	"net/http"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -17,6 +18,9 @@ type Option struct {
 
 type Kabuka struct {
 	Option
+	// httpClient and baseURL can be overridden in tests
+	httpClient *http.Client
+	baseURL    string
 }
 
 type OutputFormatType string


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with project architecture, commands, and gotchas for Claude Code
- Refactor unit tests to use `httptest` and inject `httpClient`/`baseURL`, separating unit tests from integration tests
- Add `Makefile` targets (`test`, `test-integration`, `test-coverage`) for clearer test execution
- Add `.claude/skills/add-fetcher/SKILL.md` skill documenting how to add new market fetchers
- Add `model.go` field additions and minor `kabuka.go` improvements to support testability

## Test plan

- [x] `make test` passes (unit tests, no network required)
- [x] `make test-integration` passes with live network access to Yahoo Finance
- [x] `go build ./...` succeeds