### PR TITLE
chore: migrate Go version to 1.25.9

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.25
+        go-version-file: go.mod
 
     # https://github.com/actions/cache/blob/master/examples.md#go---modules
     - uses: actions/cache@v4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.22
+        go-version: 1.25
 
     # https://github.com/actions/cache/blob/master/examples.md#go---modules
     - uses: actions/cache@v4

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version: '1.25'
 
       - name: Install dependencies
         run: go mod download

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
 
       - name: Install dependencies
         run: go mod download

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -25,6 +25,7 @@ jobs:
           # Report all results.
           filter_mode: nofilter
           fail_level: warning
+          use_go_install: true
 
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v2

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/shionit/kabuka
 
-go 1.24.0
-
-toolchain go1.24.1
+go 1.25.9
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0


### PR DESCRIPTION
## Summary

- Bump `go` directive in `go.mod` from `1.24.0` to `1.25.9`
- Run `go mod tidy` (removed redundant `toolchain` line)

Closes #83

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (all packages)