### PR TITLE
chore: update CodeQL workflow to current best practices

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,21 +1,9 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
   push:
     branches: [ main ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ main ]
   schedule:
     - cron: '28 15 * * 2'
@@ -25,7 +13,6 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
-      actions: read
       contents: read
       security-events: write
 
@@ -33,38 +20,29 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'go' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+        # CodeQL supports: actions, c-cpp, csharp, go, java-kotlin,
+        # javascript-typescript, python, ruby, swift
+        # See https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: '.go-version'
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+        queries: security-and-quality
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - name: Build
+      run: go build -v ./...
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- Replace retired `git.io` short links and stale boilerplate comments
- Drop unnecessary `actions: read` permission (least-privilege)
- Add `actions/setup-go@v5` with `go-version-file: '.go-version'` so the scan uses the same Go version the repo pins
- Replace generic `codeql-action/autobuild` with explicit `go build -v ./...`
- Enable `security-and-quality` query suite for broader coverage
- Add `category` to the `analyze` step (avoids deprecation warning when scanning multiple languages)
- Update language list comment to CodeQL v3 identifiers (`c-cpp`, `javascript-typescript`, etc.)

## Test plan

- [x] `go build -v ./...` succeeds locally
- [x] `actionlint` reports zero errors on the updated workflow file

🤖 Generated with [Claude Code](https://claude.com/claude-code)