### PR TITLE
fix: update CSS selectors to match current Yahoo Finance DOM

### DIFF
--- a/internal/app/kabuka/fetcher/fetcher.go
+++ b/internal/app/kabuka/fetcher/fetcher.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	selectorMarketNameSingle = "#root > main > div > section > div.PriceBoardMenu__3fnA.PriceBoard__menu__ISpY > span"
-	selectorMarketNameMulti  = "#root > main > div > section > div.PriceBoardMenu__3fnA.PriceBoard__menu__ISpY > div.Popup__34dI.PriceBoardMenu__popup__2i88 > button"
+	selectorMarketNameSingle = "[class*='PriceBoardMenu__label']"
+	selectorMarketNameMulti  = "[class*='PriceBoardMenu__toggle']"
 )
 
 var (

--- a/internal/app/kabuka/fetcher/fetcher_test.go
+++ b/internal/app/kabuka/fetcher/fetcher_test.go
@@ -30,8 +30,8 @@ func TestFormatPrice(t *testing.T) {
 func TestGetMarketName_single(t *testing.T) {
 	html := `<html><body>
 <div id="root"><main><div><section>
-  <div class="PriceBoardMenu__3fnA PriceBoard__menu__ISpY">
-    <span>東証PRM</span>
+  <div>
+    <span class="_PriceBoardMenu__label_92n65_18">東証PRM</span>
   </div>
 </section></div></main></div>
 </body></html>`
@@ -50,11 +50,8 @@ func TestGetMarketName_single(t *testing.T) {
 func TestGetMarketName_multi(t *testing.T) {
 	html := `<html><body>
 <div id="root"><main><div><section>
-  <div class="PriceBoardMenu__3fnA PriceBoard__menu__ISpY">
-    <span></span>
-    <div class="Popup__34dI PriceBoardMenu__popup__2i88">
-      <button>NASDAQ</button>
-    </div>
+  <div>
+    <button class="_PriceBoardMenu__toggle_92n65_18">NASDAQ<span aria-hidden="true"></span></button>
   </div>
 </section></div></main></div>
 </body></html>`
@@ -92,8 +89,8 @@ func TestSelectFetcher(t *testing.T) {
 
 	html := `<html><body>
 <div id="root"><main><div><section>
-  <div class="PriceBoardMenu__3fnA PriceBoard__menu__ISpY">
-    <span>TEST_MARKET</span>
+  <div>
+    <span class="_PriceBoardMenu__label_92n65_18">TEST_MARKET</span>
   </div>
 </section></div></main></div>
 </body></html>`

--- a/internal/app/kabuka/fetcher/jp/jp_fetcher.go
+++ b/internal/app/kabuka/fetcher/jp/jp_fetcher.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	selectorCurrentPrice = "#root > main > div > section > div.PriceBoard__main__1liM > div.PriceBoard__priceInformation__78Tl > div.PriceBoard__priceBlock__1PmX > span > span > span"
+	selectorCurrentPrice = "[class*='StyledNumber__value']"
 )
 
 var (
@@ -36,7 +36,7 @@ func (f *jpFetcher) IsMarket(doc *goquery.Document) bool {
 }
 
 func (f *jpFetcher) Fetch(doc *goquery.Document, symbol string) (*model.Stock, error) {
-	curPrice := doc.Find(selectorCurrentPrice).Text()
+	curPrice := doc.Find(selectorCurrentPrice).First().Text()
 
 	return &model.Stock{
 		Symbol:       symbol,

--- a/internal/app/kabuka/fetcher/jp/jp_fetcher_test.go
+++ b/internal/app/kabuka/fetcher/jp/jp_fetcher_test.go
@@ -11,8 +11,8 @@ import (
 func newDocWithMarket(marketName string) *goquery.Document {
 	html := fmt.Sprintf(`<html><body>
 <div id="root"><main><div><section>
-  <div class="PriceBoardMenu__3fnA PriceBoard__menu__ISpY">
-    <span>%s</span>
+  <div>
+    <span class="_PriceBoardMenu__label_92n65_18">%s</span>
   </div>
 </section></div></main></div>
 </body></html>`, marketName)
@@ -23,15 +23,11 @@ func newDocWithMarket(marketName string) *goquery.Document {
 func newDocWithPrice(marketName, price string) *goquery.Document {
 	html := fmt.Sprintf(`<html><body>
 <div id="root"><main><div><section>
-  <div class="PriceBoardMenu__3fnA PriceBoard__menu__ISpY">
-    <span>%s</span>
+  <div>
+    <span class="_PriceBoardMenu__label_92n65_18">%s</span>
   </div>
-  <div class="PriceBoard__main__1liM">
-    <div class="PriceBoard__priceInformation__78Tl">
-      <div class="PriceBoard__priceBlock__1PmX">
-        <span><span><span>%s</span></span></span>
-      </div>
-    </div>
+  <div>
+    <span class="_StyledNumber__value_1arhg_9">%s</span>
   </div>
 </section></div></main></div>
 </body></html>`, marketName, price)

--- a/internal/app/kabuka/fetcher/us/us_fetcher.go
+++ b/internal/app/kabuka/fetcher/us/us_fetcher.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	selectorCurrentPrice = "#root > main > div > section > div.PriceBoard__main__1liM > div.PriceBoard__priceInformation__78Tl > div.PriceBoard__priceBlock__1PmX > span > span > span"
+	selectorCurrentPrice = "[class*='StyledNumber__value']"
 )
 
 var (
@@ -33,7 +33,7 @@ func (f *usFetcher) IsMarket(doc *goquery.Document) bool {
 }
 
 func (f *usFetcher) Fetch(doc *goquery.Document, symbol string) (*model.Stock, error) {
-	curPrice := doc.Find(selectorCurrentPrice).Text()
+	curPrice := doc.Find(selectorCurrentPrice).First().Text()
 
 	return &model.Stock{
 		Symbol:       symbol,

--- a/internal/app/kabuka/fetcher/us/us_fetcher_test.go
+++ b/internal/app/kabuka/fetcher/us/us_fetcher_test.go
@@ -11,8 +11,8 @@ import (
 func newDocWithMarket(marketName string) *goquery.Document {
 	html := fmt.Sprintf(`<html><body>
 <div id="root"><main><div><section>
-  <div class="PriceBoardMenu__3fnA PriceBoard__menu__ISpY">
-    <span>%s</span>
+  <div>
+    <span class="_PriceBoardMenu__label_92n65_18">%s</span>
   </div>
 </section></div></main></div>
 </body></html>`, marketName)
@@ -23,15 +23,11 @@ func newDocWithMarket(marketName string) *goquery.Document {
 func newDocWithPrice(marketName, price string) *goquery.Document {
 	html := fmt.Sprintf(`<html><body>
 <div id="root"><main><div><section>
-  <div class="PriceBoardMenu__3fnA PriceBoard__menu__ISpY">
-    <span>%s</span>
+  <div>
+    <span class="_PriceBoardMenu__label_92n65_18">%s</span>
   </div>
-  <div class="PriceBoard__main__1liM">
-    <div class="PriceBoard__priceInformation__78Tl">
-      <div class="PriceBoard__priceBlock__1PmX">
-        <span><span><span>%s</span></span></span>
-      </div>
-    </div>
+  <div>
+    <span class="_StyledNumber__value_1arhg_9">%s</span>
   </div>
 </section></div></main></div>
 </body></html>`, marketName, price)

--- a/internal/app/kabuka/kabuka_test.go
+++ b/internal/app/kabuka/kabuka_test.go
@@ -16,12 +16,8 @@ import (
 func jpStockHTML(marketName, price string) string {
 	return fmt.Sprintf(`<html><body>
 <div id="root"><main><div><section>
-  <div class="PriceBoardMenu__3fnA PriceBoard__menu__ISpY"><span>%s</span></div>
-  <div class="PriceBoard__main__1liM">
-    <div class="PriceBoard__priceInformation__78Tl">
-      <div class="PriceBoard__priceBlock__1PmX"><span><span><span>%s</span></span></span></div>
-    </div>
-  </div>
+  <div><span class="_PriceBoardMenu__label_92n65_18">%s</span></div>
+  <div><span class="_StyledNumber__value_1arhg_9">%s</span></div>
 </section></div></main></div>
 </body></html>`, marketName, price)
 }


### PR DESCRIPTION
## Summary

- Yahoo Finance changed their frontend build, rotating the CSS module hash suffixes on all class names (e.g. `PriceBoardMenu__3fnA` → `_PriceBoardMenu__label_92n65_18`), which broke all JP stock fetches with `Unknown market type.`
- Replace the three hardcoded deep CSS selectors with `[class*="..."]` attribute selectors that match on the stable semantic prefix of each class name, making them resilient to future hash rotations
- Add `.First()` to the price selector — `[class*="StyledNumber__value"]` matches multiple elements on the page (current price, change, percentage, range) and `.Text()` without `.First()` concatenated all of them

## Changes

| File | What changed |
|---|---|
| `fetcher/fetcher.go` | `selectorMarketNameSingle/Multi` updated to `[class*="PriceBoardMenu__label/toggle"]` |
| `fetcher/jp/jp_fetcher.go` | `selectorCurrentPrice` → `[class*="StyledNumber__value"]`, use `.First()` |
| `fetcher/us/us_fetcher.go` | Same as above |
| `*_test.go` (×4) | Mock HTML updated to use class names matching the new selectors |

## Test plan

- [x] `make test` — all unit tests pass
- [x] `make test-integration` — all 5 live stocks pass (3994.T, 4412.T, 8604.T, NMR, AAPL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)