### PR TITLE
fix: exclude integration tests from test-coverage target

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,41 @@
+name: Integration Tests (Yahoo Finance)
+
+on:
+  schedule:
+    # 10:00 JST weekdays — TSE morning session
+    - cron: '0 1 * * 1-5'
+    # 09:30 ET weekdays — NYSE/NASDAQ open
+    - cron: '30 14 * * 1-5'
+  push:
+    branches: [ main ]
+    paths:
+      - 'internal/**'
+      - 'go.mod'
+      - 'go.sum'
+  workflow_dispatch:
+
+# Minimal default permissions; jobs declare only what they need.
+permissions:
+  contents: read
+
+jobs:
+
+  integration:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Set up Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version-file: go.mod
+
+    - name: Run integration tests
+      run: make test-integration

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ test-integration:
 	go test -v -tags integration ./...
 
 test-coverage:
-	go test -v -tags integration -coverprofile=./gotest.profile ./... 2>&1
+	go test -v -coverprofile=./gotest.profile ./... 2>&1
 	go tool cover -html=./gotest.profile -o ./coverage.html


### PR DESCRIPTION
## Summary

- `make test-coverage` was using `-tags integration`, which included `TestKabuka_fetch` — a live HTTP test against Yahoo Finance
- This caused the `build` CI job to fail on all dependabot PRs whenever the market is closed or Yahoo Finance's HTML differs
- CLAUDE.md explicitly states: *"Integration tests (build tag `integration`) are excluded from the coverage requirement"*
- Removed `-tags integration` from the `test-coverage` target; unit tests alone achieve **87.4% coverage** (above the 80% requirement)

## Root Cause

All 4 open dependabot PRs (#98, #100, #102, #103) share the same failure:

```
--- FAIL: TestKabuka_fetch/if_kabuka_AAPL_@NASDAQ_then_Apple_Inc.
FAIL  github.com/shionit/kabuka/internal/app/kabuka
make: *** [Makefile:8: test-coverage] Error 1
```

The integration tests hit Yahoo Finance over live network and are inherently flaky in CI (market hours, HTML changes). They should never block dependency updates.

## Test plan

- [x] `make test` passes (unit tests only)
- [x] `make test-coverage` passes with 87.4% coverage (no network required)
- [x] `make test-integration` still available for manual live testing